### PR TITLE
Remove workaround for broken upload API

### DIFF
--- a/datameta_client/files.py
+++ b/datameta_client/files.py
@@ -66,8 +66,7 @@ def stage(
     with open(path, 'rb') as infile:
         api_response_upload = requests.post(
                 api_response_announce['url_to_upload'],
-                # [!!] TODO THIS IS TO BE REMOVED!
-                headers={'Authorization' : 'Bearer ' + config.access_token, **api_response_announce.request_headers },
+                headers=api_response_announce.request_headers,
                 files = { 'file' : infile } )
         api_response_upload.raise_for_status()
     info("Upload completed", quiet)


### PR DESCRIPTION
* https://github.com/ghga-de/datameta/pull/193 needs to be merged first + `datameta-client-lib` 0.2.0 release